### PR TITLE
Update videoio.lua

### DIFF
--- a/cv/videoio.lua
+++ b/cv/videoio.lua
@@ -77,7 +77,7 @@ do
 		local image = t.image
 		local flag = t.flag or 0
 
-		result = C.VideoCapture_retrieve(self.ptr, cv.wrap_tensors(image), flag)
+		result = C.VideoCapture_retrieve(self.ptr, cv.wrap_tensor(image), flag)
 		return result.val, cv.unwrap_tensors(result.tensor)
 	end
 
@@ -88,7 +88,7 @@ do
 	function VideoCapture:read(t)
 		local image = t.image
 
-		result = C.VideoCapture_read(self.ptr, cv.wrap_tensors(image))
+		result = C.VideoCapture_read(self.ptr, cv.wrap_tensor(image))
 		return result.val, cv.unwrap_tensors(result.tensor)
 	end
 


### PR DESCRIPTION
follow-up on https://github.com/VisionLabs/torch-opencv/commit/2d0371dda4dfde1e603fbfe01577629320778e5c

This edit should fix the following error when using videocapture:read()

luajit: ./cv/videoio.lua:91: bad argument #2 to 'VideoCapture_read' (cannot convert 'struct TensorArray' to 'struct TensorWrapper')
stack traceback:
    [C]: in function 'VideoCapture_read'
    ./cv/videoio.lua:91: in function 'read'
