### PR TITLE
Installation from torch/rocks

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,10 @@
 OpenCV bindings for LuaJIT+Torch
 =====================
 
-Now available through LuaRocks:
+Installation:
 
 ```shell
-luarocks install --server=http://luarocks.org/dev cv
+luarocks install cv
 ```
 
 For complete info on the project, including tutorials and contribution guidelines, visit its [Wiki](https://github.com/VisionLabs/torch-opencv/wiki).


### PR DESCRIPTION
Torch maintains it's own rocks: https://github.com/torch/rocks so after https://github.com/torch/rocks/pull/99 gets merged torch-opencv can be installed as `luarocks install cv`
