### PR TITLE
ximgproc: graphsegmentation and selectivesearchsegmentation

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,14 +1,14 @@
 PROJECT(Torch_OpenCV)
 CMAKE_MINIMUM_REQUIRED(VERSION 2.8.8 FATAL_ERROR)
 
-OPTION(BUILD_TESTS  "Build C tests"         OFF)
-OPTION(BUILD_CUDA   "Wrap CUDA packages"    ON)
+OPTION(BUILD_TESTS   "Build C tests"                OFF)
+OPTION(BUILD_CUDA    "Wrap CUDA packages"           ON)
 
 SET(CMAKE_LIBRARY_OUTPUT_DIRECTORY "${CMAKE_BINARY_DIR}/lib")
 
 SET(OPENCV_MODULES_TO_WRAP
         imgcodecs highgui features2d flann imgproc ml optflow photo superres videoio video
-        objdetect calib3d)
+        objdetect calib3d ximgproc)
 
 IF (BUILD_CUDA)
     SET(OPENCV_MODULES_TO_WRAP ${OPENCV_MODULES_TO_WRAP} cudaarithm cudacodec cudawarping

--- a/cv/ximgproc/CMakeLists.txt
+++ b/cv/ximgproc/CMakeLists.txt
@@ -1,0 +1,5 @@
+CMAKE_MINIMUM_REQUIRED(VERSION 2.8 FATAL_ERROR)
+CMAKE_POLICY(VERSION 2.8)
+SET(src)
+FILE(GLOB luasrc *.lua)
+ADD_TORCH_PACKAGE(cv/ximgproc "${src}" "${luasrc}")

--- a/cv/ximgproc/init.lua
+++ b/cv/ximgproc/init.lua
@@ -1,0 +1,224 @@
+local cv = require 'cv._env'
+local ffi = require 'ffi'
+
+ffi.cdef[[
+
+struct TensorWrapper niBlackThreshold(struct TensorWrapper src, struct TensorWrapper dst, double maxValue, int type, int blockSize, double delta);
+
+]]
+
+local C = ffi.load(cv.libPath('ximgproc'))
+
+function cv.niBlackThreshold(t)
+    local argRules = {
+        {"src", required = true},
+        {"dst", default = nil},
+        {"maxValue", required = true},
+        {"type", required = true},
+        {"blockSize", required = true},
+        {"delta", required = true},
+    }
+
+    local src, dst, maxValue, type_, blockSize, delta = cv.argcheck(t, argRules)
+
+    assert(src:nDimension() == 2 and cv.tensorType(src) == cv.CV_8U)
+    assert(dst:nDimension() == 2 and cv.tensorType(dst) == cv.CV_8U)
+
+    return cv.unwrap_tensors(C.niBlackThreshold(cv.wrap_tensor(src), cv.wrap_tensor(dst), maxValue, type_, blockSize, delta))
+end
+
+
+--- ***************** Classes *****************
+require 'cv.Classes'
+
+local Classes = ffi.load(cv.libPath('Classes'))
+
+ffi.cdef[[
+
+struct PtrWrapper GraphSegmentation_ctor(double sigma, float k, int min_size);
+
+struct TensorWrapper GraphSegmentation_processImage(struct PtrWrapper ptr, struct TensorWrapper);
+
+void GraphSegmentation_setSigma(struct PtrWrapper ptr, double s);
+
+double GraphSegmentation_getSigma(struct PtrWrapper ptr);
+
+void GraphSegmentation_setK(struct PtrWrapper ptr, float k);
+
+float GraphSegmentation_getK(struct PtrWrapper ptr);
+
+void GraphSegmentation_setMinSize(struct PtrWrapper ptr, int min_size);
+
+int GraphSegmentation_getMinSize(struct PtrWrapper ptr);
+
+struct PtrWrapper SelectiveSearchSegmentation_ctor();
+
+void SelectiveSearchSegmentation_setBaseImage(struct PtrWrapper ptr, struct TensorWrapper);
+
+void SelectiveSearchSegmentation_switchToSingleStrategy(struct PtrWrapper ptr, int, float);
+
+void SelectiveSearchSegmentation_switchToSelectiveSearchFast(struct PtrWrapper ptr, int, int, float);
+
+void SelectiveSearchSegmentation_switchToSelectiveSearchQuality(struct PtrWrapper ptr, int, int, float);
+
+void SelectiveSearchSegmentation_addImage(struct PtrWrapper ptr, struct TensorWrapper);
+
+void SelectiveSearchSegmentation_clearImages(struct PtrWrapper ptr);
+
+void SelectiveSearchSegmentation_addGraphSegmentation(struct PtrWrapper ptr, struct GraphSegmentationPtr);
+
+void SelectiveSearchSegmentation_clearGraphSegmentations(struct PtrWrapper ptr);
+
+void SelectiveSearchSegmentation_addStrategy(struct PtrWrapper ptr, struct SelectiveSearchSegmentationStrategyPtr);
+
+void SelectiveSearchSegmentation_clearStrategies(struct PtrWrapper ptr);
+
+struct RectArray SelectiveSearchSegmentation_process(struct PtrWrapper ptr);
+
+
+]]
+
+
+do
+    local GraphSegmentation = torch.class('cv.GraphSegmentation', 'cv.Algorithm', cv)
+
+    function GraphSegmentation:__init(t)
+
+        local argRules = {
+            {"sigma", default = 0.5},
+            {"k", default = 300},
+            {"min_size", default = 100},
+        }
+        local sigma, k, min_size = cv.argcheck(t, argRules)
+
+        self.ptr = ffi.gc(C.GraphSegmentation_ctor(sigma, k, min_size), Classes.Algorithm_dtor)
+    end
+
+    function GraphSegmentation:processImage(t)
+
+        local argRules = {
+            {"src", required = true},
+        }
+        local src = cv.argcheck(t, argRules)
+
+        return cv.unwrap_tensors(C.GraphSegmentation_processImage(self.ptr, cv.wrap_tensor(src)))
+    end
+
+    function GraphSegmentation:setSigma(s)
+        C.GraphSegmentation_setSigma(self.ptr, s)
+    end
+
+    function GraphSegmentation:getSigma()
+        return C.GraphSegmentation_getSigma(self.ptr)
+    end
+
+    function GraphSegmentation:setK(k)
+        C.GraphSegmentation_setK(self.ptr, k)
+    end
+
+    function GraphSegmentation:getK()
+        return C.GraphSegmentation_getK(self.ptr)
+    end
+
+    function GraphSegmentation:setMinSize(s)
+        C.GraphSegmentation_setMinSize(self.ptr, s)
+    end
+
+    function GraphSegmentation:getMinSize()
+        return C.GraphSegmentation_getMinSize(self.ptr)
+    end
+
+end
+
+do
+
+    local SelectiveSearchSegmentation = torch.class('cv.SelectiveSearchSegmentation', 'cv.Algorithm', cv)
+
+    function SelectiveSearchSegmentation:__init()
+
+        self.ptr = ffi.gc(C.SelectiveSearchSegmentation_ctor(), Classes.Algorithm_dtor)
+    end
+
+    function SelectiveSearchSegmentation:setBaseImage(t)
+
+        local argRules = {
+            {"img", required = true},
+        }
+        local img = cv.argcheck(t, argRules)
+
+        C.SelectiveSearchSegmentation_setBaseImage(self.ptr, cv.wrap_tensor(img))
+    end
+
+    function SelectiveSearchSegmentation:switchToSingleStrategy(t)
+
+        local argRules = {
+            {"k", default = 200},
+            {"sigma", default = 0.8},
+        }
+        local k, sigma = cv.argcheck(t, argRules)
+
+        C.SelectiveSearchSegmentation_switchToSingleStrategy(self.ptr, k, sigma)
+    end
+
+
+    function SelectiveSearchSegmentation:switchToSelectiveSearchFast(t)
+
+        local argRules = {
+            {"k", default = 150},
+            {"inc_k", default = 150},
+            {"sigma", default = 0.8},
+        }
+        local k, inc_k, sigma = cv.argcheck(t, argRules)
+
+        C.SelectiveSearchSegmentation_switchToSelectiveSearchFast(self.ptr, k, inc_k, sigma)
+    end
+
+    function SelectiveSearchSegmentation:switchToSelectiveSearchQuality(t)
+
+        local argRules = {
+            {"k", default = 150},
+            {"inc_k", default = 150},
+            {"sigma", default = 0.8},
+        }
+        local k, inc_k, sigma = cv.argcheck(t, argRules)
+
+        C.SelectiveSearchSegmentation_switchToSelectiveSearchQuality(self.ptr, k, inc_k, sigma)
+    end
+
+    function SelectiveSearchSegmentation:addImage(t)
+
+        local argRules = {
+            {"img", required = true},
+        }
+        local img = cv.argcheck(t, argRules)
+
+        C.SelectiveSearchSegmentation_addImage(self.ptr, cv.wrap_tensor(img))
+    end
+
+    function SelectiveSearchSegmentation:clearImages()
+        C.SelectiveSearchSegmentation_clearImages(self.ptr)
+    end
+
+    function SelectiveSearchSegmentation:addGraphSegmentation(gs)
+        C.SelectiveSearchSegmentation_addGraphSegmentation(self.ptr, gs.ptr)
+    end
+
+    function SelectiveSearchSegmentation:clearGraphSegmentations()
+        C.SelectiveSearchSegmentation_clearGraphSegmentations(self.ptr)
+    end
+
+    function SelectiveSearchSegmentation:addStrategy(s)
+        C.SelectiveSearchSegmentation_addStrategy(self.ptr, s.ptr)
+    end
+
+    function SelectiveSearchSegmentation:clearStrategies()
+        C.SelectiveSearchSegmentation_clearStrategies(self.ptr)
+    end
+
+    function SelectiveSearchSegmentation:process()
+        return cv.gcarray(C.SelectiveSearchSegmentation_process(self.ptr))
+    end
+
+end
+
+return cv

--- a/include/ximgproc.hpp
+++ b/include/ximgproc.hpp
@@ -1,0 +1,122 @@
+#include <Common.hpp>
+#include <Classes.hpp>
+#include <opencv2/ximgproc.hpp>
+
+
+extern "C"
+struct TensorWrapper niBlackThreshold(struct TensorWrapper src, struct TensorWrapper dst, double maxValue, int type, int blockSize, double delta);
+
+
+// GraphSegmentation
+struct GraphSegmentationPtr {
+    void *ptr;
+
+    inline cv::ximgproc::segmentation::GraphSegmentation * operator->() { return static_cast<cv::ximgproc::segmentation::GraphSegmentation *>(ptr); }
+    inline cv::ximgproc::segmentation::GraphSegmentation * operator*() { return static_cast<cv::ximgproc::segmentation::GraphSegmentation *>(ptr); }
+    inline GraphSegmentationPtr(cv::ximgproc::segmentation::GraphSegmentation *ptr) { this->ptr = ptr; }
+};
+
+// GraphSegmentation
+extern "C"
+struct GraphSegmentationPtr GraphSegmentation_ctor(double sigma, float k, int min_size);
+
+extern "C"
+struct TensorWrapper GraphSegmentation_processImage(struct GraphSegmentationPtr ptr, struct TensorWrapper);
+
+extern "C"
+void GraphSegmentation_setSigma(struct GraphSegmentationPtr ptr, double s);
+
+extern "C"
+double GraphSegmentation_getSigma(struct GraphSegmentationPtr ptr);
+
+extern "C"
+void GraphSegmentation_setK(struct GraphSegmentationPtr ptr, float k);
+
+extern "C"
+float GraphSegmentation_getK(struct GraphSegmentationPtr ptr);
+
+extern "C"
+void GraphSegmentation_setMinSize(struct GraphSegmentationPtr ptr, int min_size);
+
+extern "C"
+int GraphSegmentation_getMinSize(struct GraphSegmentationPtr ptr);
+
+
+// SelectiveSearchSegmentationStrategy
+struct SelectiveSearchSegmentationStrategyPtr {
+    void *ptr;
+
+    inline cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy * operator->() { return static_cast<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *>(ptr); }
+    inline cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy * operator*() { return static_cast<cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *>(ptr); }
+    inline SelectiveSearchSegmentationStrategyPtr(cv::ximgproc::segmentation::SelectiveSearchSegmentationStrategy *ptr) { this->ptr = ptr; }
+};
+//
+// extern "C"
+// struct SelectiveSearchSegmentationStrategyPtr SelectiveSearchSegmentationStrategyColor_ctor();
+//
+// extern "C"
+// struct SelectiveSearchSegmentationStrategyPtr SelectiveSearchSegmentationStrategySize_ctor();
+//
+// extern "C"
+// struct SelectiveSearchSegmentationStrategyPtr SelectiveSearchSegmentationStrategyTexture_ctor();
+//
+// extern "C"
+// struct SelectiveSearchSegmentationStrategyPtr SelectiveSearchSegmentationStrategyFill_ctor();
+//
+// extern "C"
+// void SelectiveSearchSegmentationStrategy_setImage(struct SelectiveSearchSegmentationStrategyPtr ptr, struct TensorWrapper, struct TensorWrapper, struct TensorWrapper, int);
+//
+// extern "C"
+// float SelectiveSearchSegmentationStrategy_get(int, int);
+//
+// extern "C"
+// void SelectiveSearchSegmentationStrategy_merge(int, int);
+
+
+// MULTIPLE STRTEGY
+//
+
+// SelectiveSearchSegmentation
+struct SelectiveSearchSegmentationPtr {
+    void *ptr;
+
+    inline cv::ximgproc::segmentation::SelectiveSearchSegmentation * operator->() { return static_cast<cv::ximgproc::segmentation::SelectiveSearchSegmentation *>(ptr); }
+    inline cv::ximgproc::segmentation::SelectiveSearchSegmentation * operator*() { return static_cast<cv::ximgproc::segmentation::SelectiveSearchSegmentation *>(ptr); }
+    inline SelectiveSearchSegmentationPtr(cv::ximgproc::segmentation::SelectiveSearchSegmentation *ptr) { this->ptr = ptr; }
+};
+
+extern "C"
+struct SelectiveSearchSegmentationPtr SelectiveSearchSegmentation_ctor();
+
+extern "C"
+void SelectiveSearchSegmentation_setBaseImage(struct SelectiveSearchSegmentationPtr ptr, struct TensorWrapper);
+
+extern "C"
+void SelectiveSearchSegmentation_switchToSingleStrategy(struct SelectiveSearchSegmentationPtr ptr, int, float);
+
+extern "C"
+void SelectiveSearchSegmentation_switchToSelectiveSearchFast(struct SelectiveSearchSegmentationPtr ptr, int, int, float);
+
+extern "C"
+void SelectiveSearchSegmentation_switchToSelectiveSearchQuality(struct SelectiveSearchSegmentationPtr ptr, int, int, float);
+
+extern "C"
+void SelectiveSearchSegmentation_addImage(struct SelectiveSearchSegmentationPtr ptr, struct TensorWrapper);
+
+extern "C"
+void SelectiveSearchSegmentation_clearImages(struct SelectiveSearchSegmentationPtr ptr);
+
+extern "C"
+void SelectiveSearchSegmentation_addGraphSegmentation(struct SelectiveSearchSegmentationPtr ptr, struct GraphSegmentationPtr);
+
+extern "C"
+void SelectiveSearchSegmentation_clearGraphSegmentations(struct SelectiveSearchSegmentationPtr ptr);
+
+extern "C"
+void SelectiveSearchSegmentation_addStrategy(struct SelectiveSearchSegmentationPtr ptr, struct SelectiveSearchSegmentationStrategyPtr);
+
+extern "C"
+void SelectiveSearchSegmentation_clearStrategies(struct SelectiveSearchSegmentationPtr ptr);
+
+extern "C"
+struct RectArray SelectiveSearchSegmentation_process(struct SelectiveSearchSegmentationPtr ptr);

--- a/src/ximgproc.cpp
+++ b/src/ximgproc.cpp
@@ -1,0 +1,136 @@
+#include <ximgproc.hpp>
+
+extern "C"
+struct TensorWrapper niBlackThreshold(struct TensorWrapper src, struct TensorWrapper dst, double maxValue, int type, int blockSize, double delta) {
+
+    cv::Mat dst_mat;
+    if(!dst.isNull()) dst_mat = dst.toMat();
+
+    cv::ximgproc::niBlackThreshold(src.toMat(), dst_mat, maxValue, type, blockSize, delta);
+
+    return TensorWrapper(dst_mat);
+}
+
+// GraphSegmentation
+
+extern "C"
+struct GraphSegmentationPtr GraphSegmentation_ctor(double sigma, float k, int min_size) {
+    return rescueObjectFromPtr(cv::ximgproc::segmentation::createGraphSegmentation(sigma, k, min_size));
+}
+
+extern "C"
+void GraphSegmentation_dtor(struct GraphSegmentationPtr ptr) {
+    delete static_cast<cv::ximgproc::segmentation::GraphSegmentation *>(ptr.ptr);
+}
+
+extern "C"
+struct TensorWrapper GraphSegmentation_processImage(struct GraphSegmentationPtr ptr, struct TensorWrapper img) {
+
+    cv::Mat result;
+    ptr->processImage(img.toMat(), result);
+    return TensorWrapper(result);
+}
+
+extern "C"
+void GraphSegmentation_setSigma(struct GraphSegmentationPtr ptr, double s) {
+    ptr->setSigma(s);
+}
+
+extern "C"
+double GraphSegmentation_getSigma(struct GraphSegmentationPtr ptr) {
+    return ptr->getSigma();
+}
+
+extern "C"
+void GraphSegmentation_setK(struct GraphSegmentationPtr ptr, float k) {
+    ptr->setK(k);
+}
+
+extern "C"
+float GraphSegmentation_getK(struct GraphSegmentationPtr ptr) {
+    return ptr->getK();
+}
+
+extern "C"
+void GraphSegmentation_setMinSize(struct GraphSegmentationPtr ptr, int min_size) {
+    ptr->setMinSize(min_size);
+}
+
+extern "C"
+int GraphSegmentation_getMinSize(struct GraphSegmentationPtr ptr) {
+    return ptr->getMinSize();
+}
+
+
+
+
+// SelectiveSearchSegmentation
+
+extern "C"
+struct SelectiveSearchSegmentationPtr SelectiveSearchSegmentation_ctor() {
+    return rescueObjectFromPtr(cv::ximgproc::segmentation::createSelectiveSearchSegmentation());
+}
+
+extern "C"
+void SelectiveSearchSegmentationPtr_dtor(struct SelectiveSearchSegmentationPtr ptr) {
+    delete static_cast<cv::ximgproc::segmentation::SelectiveSearchSegmentation *>(ptr.ptr);
+}
+
+extern "C"
+void SelectiveSearchSegmentation_setBaseImage(struct SelectiveSearchSegmentationPtr ptr, struct TensorWrapper img) {
+    ptr->setBaseImage(img.toMat());
+}
+
+extern "C"
+void SelectiveSearchSegmentation_switchToSingleStrategy(struct SelectiveSearchSegmentationPtr ptr, int k, float sigma) {
+    ptr->switchToSingleStrategy(k, sigma);
+}
+
+extern "C"
+void SelectiveSearchSegmentation_switchToSelectiveSearchFast(struct SelectiveSearchSegmentationPtr ptr, int k, int inc_k, float sigma) {
+    ptr->switchToSelectiveSearchFast(k, inc_k, sigma);
+}
+
+extern "C"
+void SelectiveSearchSegmentation_switchToSelectiveSearchQuality(struct SelectiveSearchSegmentationPtr ptr, int k, int inc_k, float sigma) {
+    ptr->switchToSelectiveSearchQuality(k, inc_k, sigma);
+}
+
+extern "C"
+void SelectiveSearchSegmentation_addImage(struct SelectiveSearchSegmentationPtr ptr, struct TensorWrapper img) {
+    ptr->setBaseImage(img.toMat());
+}
+
+extern "C"
+void SelectiveSearchSegmentation_clearImages(struct SelectiveSearchSegmentationPtr ptr) {
+    ptr->clearImages();
+}
+
+extern "C"
+void SelectiveSearchSegmentation_addGraphSegmentation(struct SelectiveSearchSegmentationPtr ptr, struct GraphSegmentationPtr gs) {
+    ptr->addGraphSegmentation(*gs);
+}
+
+extern "C"
+void SelectiveSearchSegmentation_clearGraphSegmentations(struct SelectiveSearchSegmentationPtr ptr) {
+    ptr->clearGraphSegmentations();
+}
+
+extern "C"
+void SelectiveSearchSegmentation_addStrategy(struct SelectiveSearchSegmentationPtr ptr, struct SelectiveSearchSegmentationStrategyPtr s) {
+    ptr->addStrategy(*s);
+}
+
+extern "C"
+void SelectiveSearchSegmentation_clearStrategies(struct SelectiveSearchSegmentationPtr ptr) {
+    ptr->clearStrategies();
+}
+
+extern "C"
+struct RectArray SelectiveSearchSegmentation_process(struct SelectiveSearchSegmentationPtr ptr) {
+
+    std::vector<cv::Rect> result;
+    ptr->process(result);
+
+    return RectArray(result);
+}


### PR DESCRIPTION
This is a very basic PR for ximgproc.

I implemented only the features I needed, so more works is needed for the full ximgproc implementation, but I can already be usefull and/or a base for futur work.

This need to be build with a recent version of opencv_contrib. I added a cmake option to disable the requirement of opencv_contrib as it's an option in opencv.

Related to #69 .
