### PR TITLE
fix bug in convexHull if returnPoints is false

### DIFF
--- a/cv/imgproc/init.lua
+++ b/cv/imgproc/init.lua
@@ -2068,9 +2068,7 @@ function cv.convexHull(t)
 				clockwise, returnPoints))
     if not returnPoints then
         -- correct the 0-based indexing
-        for i = 1, retval:size(1) do
-            retval[i] = retval[i] + 1
-        end
+        retval:add(1)
     end
     return retval
 end

--- a/cv/imgproc/init.lua
+++ b/cv/imgproc/init.lua
@@ -2068,7 +2068,7 @@ function cv.convexHull(t)
 				clockwise, returnPoints))
     if not returnPoints then
         -- correct the 0-based indexing
-        for i = 1,#retval do
+        for i = 1, retval:size(1) do
             retval[i] = retval[i] + 1
         end
     end


### PR DESCRIPTION
retval is in case of returnPoints false a torch.LongTensor.
Therefore we can get the size only with the size method.